### PR TITLE
도시 상세페이지 로컬 스토리지 기반 좋아요/싫어요 기능 구현

### DIFF
--- a/src/app/cities/[id]/not-found.tsx
+++ b/src/app/cities/[id]/not-found.tsx
@@ -1,0 +1,69 @@
+import Link from 'next/link';
+import { Button } from '@/components/ui/button';
+import { Home, Search } from 'lucide-react';
+
+export default function NotFound() {
+  return (
+    <div className="min-h-screen flex items-center justify-center px-4">
+      <div className="text-center max-w-2xl">
+        {/* 이모지 */}
+        <div className="text-8xl mb-6">🗺️</div>
+
+        {/* 타이틀 */}
+        <h1 className="text-4xl sm:text-5xl font-bold mb-4">
+          도시를 찾을 수 없습니다
+        </h1>
+
+        {/* 설명 */}
+        <p className="text-lg text-muted-foreground mb-8">
+          요청하신 도시 정보가 존재하지 않습니다.
+          <br />
+          URL을 확인하시거나 다른 도시를 탐색해보세요.
+        </p>
+
+        {/* 버튼들 */}
+        <div className="flex flex-col sm:flex-row gap-4 justify-center">
+          <Link href="/">
+            <Button size="lg" className="gap-2 w-full sm:w-auto">
+              <Home className="w-5 h-5" />
+              홈으로 돌아가기
+            </Button>
+          </Link>
+          <Link href="/#cities">
+            <Button size="lg" variant="outline" className="gap-2 w-full sm:w-auto">
+              <Search className="w-5 h-5" />
+              도시 둘러보기
+            </Button>
+          </Link>
+        </div>
+
+        {/* 추가 도움말 */}
+        <div className="mt-12 p-6 bg-muted/50 rounded-xl">
+          <h2 className="font-semibold mb-3">인기 도시를 찾고 계신가요?</h2>
+          <div className="flex flex-wrap gap-2 justify-center">
+            <Link href="/cities/seoul-gangnam">
+              <Button variant="ghost" size="sm">
+                강남
+              </Button>
+            </Link>
+            <Link href="/cities/jeju-city">
+              <Button variant="ghost" size="sm">
+                제주시
+              </Button>
+            </Link>
+            <Link href="/cities/busan-haeundae">
+              <Button variant="ghost" size="sm">
+                해운대
+              </Button>
+            </Link>
+            <Link href="/cities/jeonju">
+              <Button variant="ghost" size="sm">
+                전주
+              </Button>
+            </Link>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/app/cities/[id]/page.tsx
+++ b/src/app/cities/[id]/page.tsx
@@ -1,0 +1,106 @@
+import { notFound } from 'next/navigation';
+import { Metadata } from 'next';
+import { mockCities, getCityById } from '@/data/mock/cities';
+import CityDetailHero from '@/components/sections/CityDetailHero';
+import CostBreakdown from '@/components/sections/CostBreakdown';
+import CityHighlights from '@/components/sections/CityHighlights';
+import CityStats from '@/components/sections/CityStats';
+import RelatedCities from '@/components/sections/RelatedCities';
+
+interface CityPageProps {
+  params: Promise<{
+    id: string;
+  }>;
+}
+
+// 정적 페이지 생성을 위한 경로 목록
+export async function generateStaticParams() {
+  return mockCities.map((city) => ({
+    id: city.id,
+  }));
+}
+
+// SEO 메타데이터 생성
+export async function generateMetadata({
+  params,
+}: CityPageProps): Promise<Metadata> {
+  const { id } = await params;
+  const city = getCityById(id);
+
+  if (!city) {
+    return {
+      title: '도시를 찾을 수 없습니다',
+    };
+  }
+
+  const formatCurrency = (amount: number) => {
+    return new Intl.NumberFormat('ko-KR', {
+      style: 'currency',
+      currency: 'KRW',
+      maximumFractionDigits: 0,
+    }).format(amount);
+  };
+
+  return {
+    title: `${city.name} (${city.nameEn}) - Korean Nomad`,
+    description: `${city.description} 월 평균 생활비: ${formatCurrency(
+      city.costOfLiving.total
+    )}. ${city.highlights.slice(0, 2).join(', ')}`,
+    keywords: [
+      city.name,
+      city.nameEn,
+      '디지털 노마드',
+      '한국',
+      '원격근무',
+      '생활비',
+      ...city.tags,
+    ],
+    openGraph: {
+      title: `${city.name} - Korean Nomad`,
+      description: city.description,
+      type: 'website',
+      images: [
+        {
+          url: city.image,
+          width: 1200,
+          height: 630,
+          alt: city.name,
+        },
+      ],
+    },
+    twitter: {
+      card: 'summary_large_image',
+      title: `${city.name} - Korean Nomad`,
+      description: city.description,
+      images: [city.image],
+    },
+  };
+}
+
+export default async function CityPage({ params }: CityPageProps) {
+  const { id } = await params;
+  const city = getCityById(id);
+
+  if (!city) {
+    notFound();
+  }
+
+  return (
+    <main className="min-h-screen">
+      {/* Hero 섹션 */}
+      <CityDetailHero city={city} />
+
+      {/* 생활비 분석 섹션 */}
+      <CostBreakdown city={city} />
+
+      {/* 도시 하이라이트 섹션 */}
+      <CityHighlights city={city} />
+
+      {/* 도시 통계 섹션 */}
+      <CityStats city={city} />
+
+      {/* 관련 도시 추천 섹션 */}
+      <RelatedCities city={city} />
+    </main>
+  );
+}

--- a/src/components/sections/CityDetailHero.tsx
+++ b/src/components/sections/CityDetailHero.tsx
@@ -1,0 +1,168 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import Image from 'next/image';
+import { City } from '@/types';
+import { ThumbsUp, ThumbsDown } from 'lucide-react';
+import { getCityPreference, setCityPreference } from '@/lib/localStorage';
+import { formatCurrency } from '@/lib/utils';
+
+interface CityDetailHeroProps {
+  city: City;
+}
+
+export default function CityDetailHero({ city }: CityDetailHeroProps) {
+  const [liked, setLiked] = useState(false);
+  const [disliked, setDisliked] = useState(false);
+  const [likeCount, setLikeCount] = useState(city.likes);
+  const [dislikeCount, setDislikeCount] = useState(city.dislikes);
+
+  // 로컬 스토리지에서 좋아요/싫어요 상태 로드
+  useEffect(() => {
+    const preference = getCityPreference(city.id);
+    if (preference) {
+      setLiked(preference.liked);
+      setDisliked(preference.disliked);
+
+      // 카운트 조정 (로컬 상태와 저장된 상태 차이만큼)
+      if (preference.liked) {
+        setLikeCount(prev => prev + 1);
+      }
+      if (preference.disliked) {
+        setDislikeCount(prev => prev + 1);
+      }
+    }
+  }, [city.id]);
+
+  const handleLike = () => {
+    const newLiked = !liked;
+    const newDisliked = newLiked ? false : disliked;
+
+    setLiked(newLiked);
+    if (newLiked) {
+      setLikeCount(prev => prev + 1);
+      if (disliked) {
+        setDisliked(false);
+        setDislikeCount(prev => prev - 1);
+      }
+    } else {
+      setLikeCount(prev => prev - 1);
+    }
+
+    // 로컬 스토리지에 저장
+    setCityPreference(city.id, newLiked, newDisliked);
+  };
+
+  const handleDislike = () => {
+    const newDisliked = !disliked;
+    const newLiked = newDisliked ? false : liked;
+
+    setDisliked(newDisliked);
+    if (newDisliked) {
+      setDislikeCount(prev => prev + 1);
+      if (liked) {
+        setLiked(false);
+        setLikeCount(prev => prev - 1);
+      }
+    } else {
+      setDislikeCount(prev => prev - 1);
+    }
+
+    // 로컬 스토리지에 저장
+    setCityPreference(city.id, newLiked, newDisliked);
+  };
+
+  return (
+    <div className="relative w-full h-[60vh] min-h-[500px] overflow-hidden">
+      {/* 배경 이미지 */}
+      <Image
+        src={city.image}
+        alt={city.name}
+        fill
+        priority
+        className="object-cover"
+      />
+
+      {/* 그라데이션 오버레이 */}
+      <div className="absolute inset-0 bg-gradient-to-b from-black/30 via-black/50 to-black/70" />
+
+      {/* 콘텐츠 */}
+      <div className="absolute inset-0 flex items-end">
+        <div className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 pb-12 sm:pb-16">
+          <div className="flex items-end justify-between gap-6 flex-wrap">
+            {/* 왼쪽: 도시 정보 */}
+            <div className="flex-1 min-w-[300px]">
+              <div className="flex items-center gap-4 mb-4">
+                <div className="bg-white rounded-full w-16 h-16 sm:w-20 sm:h-20 flex items-center justify-center text-4xl sm:text-5xl shadow-lg">
+                  {city.emoji}
+                </div>
+                <div>
+                  <h1 className="text-4xl sm:text-5xl lg:text-6xl font-bold text-white mb-2">
+                    {city.name}
+                  </h1>
+                  <p className="text-lg sm:text-xl text-white/90">
+                    {city.nameEn}
+                  </p>
+                </div>
+              </div>
+              <p className="text-base sm:text-lg text-white/95 max-w-2xl leading-relaxed">
+                {city.description}
+              </p>
+              <div className="mt-6">
+                <div className="inline-flex items-center gap-2 bg-white/20 backdrop-blur-sm rounded-full px-6 py-3">
+                  <span className="text-2xl sm:text-3xl font-bold text-white">
+                    {formatCurrency(city.costOfLiving.total)}
+                  </span>
+                  <span className="text-sm sm:text-base text-white/90">/월</span>
+                </div>
+              </div>
+            </div>
+
+            {/* 오른쪽: 좋아요/싫어요 */}
+            <div className="flex flex-col gap-3">
+              <button
+                onClick={handleLike}
+                className="flex items-center gap-3 bg-white/20 backdrop-blur-sm hover:bg-white/30 transition-all rounded-full px-6 py-3 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-transparent"
+                aria-label={liked ? `${city.name} 좋아요 취소` : `${city.name} 좋아요`}
+                aria-pressed={liked}
+              >
+                <ThumbsUp
+                  className={`w-6 h-6 ${
+                    liked ? 'fill-blue-400 text-blue-400' : 'text-white'
+                  }`}
+                />
+                <span
+                  className={`text-lg font-bold ${
+                    liked ? 'text-blue-400' : 'text-white'
+                  }`}
+                >
+                  {likeCount}
+                </span>
+              </button>
+
+              <button
+                onClick={handleDislike}
+                className="flex items-center gap-3 bg-white/20 backdrop-blur-sm hover:bg-white/30 transition-all rounded-full px-6 py-3 focus:outline-none focus:ring-2 focus:ring-white focus:ring-offset-2 focus:ring-offset-transparent"
+                aria-label={disliked ? `${city.name} 싫어요 취소` : `${city.name} 싫어요`}
+                aria-pressed={disliked}
+              >
+                <ThumbsDown
+                  className={`w-6 h-6 ${
+                    disliked ? 'fill-red-400 text-red-400' : 'text-white'
+                  }`}
+                />
+                <span
+                  className={`text-lg font-bold ${
+                    disliked ? 'text-red-400' : 'text-white'
+                  }`}
+                >
+                  {dislikeCount}
+                </span>
+              </button>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/sections/CityHighlights.tsx
+++ b/src/components/sections/CityHighlights.tsx
@@ -1,0 +1,112 @@
+import { City } from '@/types';
+import { Card, CardContent } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import { Sparkles, MapPin, Leaf, Sun } from 'lucide-react';
+
+interface CityHighlightsProps {
+  city: City;
+}
+
+export default function CityHighlights({ city }: CityHighlightsProps) {
+  return (
+    <section className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 bg-muted/30">
+      <div className="mb-8">
+        <h2 className="text-3xl sm:text-4xl font-bold mb-2">도시 하이라이트</h2>
+        <p className="text-muted-foreground">
+          {city.name}의 주요 특징과 매력 포인트입니다
+        </p>
+      </div>
+
+      {/* 주요 특징 카드 */}
+      <div className="grid gap-4 sm:grid-cols-2 lg:grid-cols-3 mb-8">
+        {city.highlights.map((highlight, index) => (
+          <Card key={index} className="hover-lift">
+            <CardContent className="pt-6">
+              <div className="flex items-start gap-3">
+                <Sparkles className="w-5 h-5 text-primary mt-1 flex-shrink-0" />
+                <p className="text-sm leading-relaxed">{highlight}</p>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      {/* 카테고리 정보 */}
+      <div className="grid gap-6 md:grid-cols-2 lg:grid-cols-4">
+        {/* 지역 */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <MapPin className="w-5 h-5 text-primary" />
+              <h3 className="font-semibold">지역</h3>
+            </div>
+            <Badge variant="secondary" className="text-sm">
+              {city.region_category}
+            </Badge>
+          </CardContent>
+        </Card>
+
+        {/* 예산 */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Sparkles className="w-5 h-5 text-primary" />
+              <h3 className="font-semibold">예산</h3>
+            </div>
+            <Badge variant="secondary" className="text-sm">
+              {city.budget}
+            </Badge>
+          </CardContent>
+        </Card>
+
+        {/* 환경 */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Leaf className="w-5 h-5 text-primary" />
+              <h3 className="font-semibold">환경</h3>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {city.environment.map((env) => (
+                <Badge key={env} variant="secondary" className="text-xs">
+                  {env}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* 추천 계절 */}
+        <Card>
+          <CardContent className="pt-6">
+            <div className="flex items-center gap-2 mb-3">
+              <Sun className="w-5 h-5 text-primary" />
+              <h3 className="font-semibold">추천 계절</h3>
+            </div>
+            <div className="flex flex-wrap gap-2">
+              {city.best_season.map((season) => (
+                <Badge key={season} variant="secondary" className="text-xs">
+                  {season}
+                </Badge>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* 태그 */}
+      {city.tags && city.tags.length > 0 && (
+        <div className="mt-8">
+          <h3 className="font-semibold mb-4">관련 태그</h3>
+          <div className="flex flex-wrap gap-2">
+            {city.tags.map((tag) => (
+              <Badge key={tag} variant="outline" className="text-sm">
+                #{tag}
+              </Badge>
+            ))}
+          </div>
+        </div>
+      )}
+    </section>
+  );
+}

--- a/src/components/sections/CityStats.tsx
+++ b/src/components/sections/CityStats.tsx
@@ -1,0 +1,102 @@
+import { City } from '@/types';
+import { Card, CardContent } from '@/components/ui/card';
+import { Users, Wifi, Briefcase, Coffee } from 'lucide-react';
+
+interface CityStatsProps {
+  city: City;
+}
+
+export default function CityStats({ city }: CityStatsProps) {
+  const stats = [
+    {
+      label: '인구',
+      value: city.population.toLocaleString('ko-KR'),
+      unit: '명',
+      icon: Users,
+      color: 'text-blue-600',
+      bgColor: 'bg-blue-50',
+    },
+    {
+      label: '인터넷 속도',
+      value: city.internetSpeed.toLocaleString('ko-KR'),
+      unit: 'Mbps',
+      icon: Wifi,
+      color: 'text-green-600',
+      bgColor: 'bg-green-50',
+    },
+    {
+      label: '코워킹 스페이스',
+      value: city.coworkingSpaces.toLocaleString('ko-KR'),
+      unit: '개',
+      icon: Briefcase,
+      color: 'text-purple-600',
+      bgColor: 'bg-purple-50',
+    },
+    {
+      label: 'WiFi 카페',
+      value: city.cafesWithWifi.toLocaleString('ko-KR'),
+      unit: '개',
+      icon: Coffee,
+      color: 'text-orange-600',
+      bgColor: 'bg-orange-50',
+    },
+  ];
+
+  return (
+    <section className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="mb-8">
+        <h2 className="text-3xl sm:text-4xl font-bold mb-2">도시 통계</h2>
+        <p className="text-muted-foreground">
+          {city.name}의 주요 통계 정보입니다
+        </p>
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+        {stats.map((stat) => {
+          const Icon = stat.icon;
+
+          return (
+            <Card key={stat.label} className="hover-lift">
+              <CardContent className="pt-6">
+                <div className="flex items-start justify-between mb-4">
+                  <div className={`p-3 rounded-xl ${stat.bgColor}`}>
+                    <Icon className={`w-6 h-6 ${stat.color}`} />
+                  </div>
+                </div>
+                <div className="space-y-1">
+                  <p className="text-sm text-muted-foreground">{stat.label}</p>
+                  <div className="flex items-baseline gap-1">
+                    <span className="text-3xl font-bold">{stat.value}</span>
+                    <span className="text-sm text-muted-foreground">{stat.unit}</span>
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+
+      {/* 리뷰 정보 */}
+      {city.reviewCount > 0 && (
+        <Card className="mt-6 hover-lift">
+          <CardContent className="pt-6">
+            <div className="flex items-center justify-between">
+              <div>
+                <h3 className="font-semibold mb-1">사용자 리뷰</h3>
+                <p className="text-sm text-muted-foreground">
+                  실제 노마드들의 생생한 후기
+                </p>
+              </div>
+              <div className="text-right">
+                <span className="text-3xl font-bold text-primary">
+                  {city.reviewCount.toLocaleString('ko-KR')}
+                </span>
+                <p className="text-sm text-muted-foreground">개의 리뷰</p>
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      )}
+    </section>
+  );
+}

--- a/src/components/sections/CostBreakdown.tsx
+++ b/src/components/sections/CostBreakdown.tsx
@@ -1,0 +1,113 @@
+import { City } from '@/types';
+import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
+import { formatCurrency } from '@/lib/utils';
+import { Home, Utensils, Bus, Wallet } from 'lucide-react';
+
+interface CostBreakdownProps {
+  city: City;
+}
+
+export default function CostBreakdown({ city }: CostBreakdownProps) {
+  const { costOfLiving } = city;
+
+  const costItems = [
+    {
+      label: '숙박비',
+      amount: costOfLiving.accommodation,
+      icon: Home,
+      color: 'bg-blue-500',
+    },
+    {
+      label: '식비',
+      amount: costOfLiving.food,
+      icon: Utensils,
+      color: 'bg-green-500',
+    },
+    {
+      label: '교통비',
+      amount: costOfLiving.transportation,
+      icon: Bus,
+      color: 'bg-orange-500',
+    },
+  ];
+
+  // 각 항목의 비율 계산
+  const getPercentage = (amount: number) => {
+    return (amount / costOfLiving.total) * 100;
+  };
+
+  return (
+    <section className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12">
+      <div className="mb-8">
+        <h2 className="text-3xl sm:text-4xl font-bold mb-2">생활비 분석</h2>
+        <p className="text-muted-foreground">
+          {city.name}에서의 월평균 생활비 세부 내역입니다
+        </p>
+      </div>
+
+      <div className="grid gap-6 md:grid-cols-2">
+        {/* 세부 항목 카드 */}
+        {costItems.map((item) => {
+          const Icon = item.icon;
+          const percentage = getPercentage(item.amount);
+
+          return (
+            <Card key={item.label} className="overflow-hidden hover-lift">
+              <CardHeader className="pb-3">
+                <div className="flex items-center justify-between">
+                  <CardTitle className="text-lg font-semibold flex items-center gap-2">
+                    <div className={`p-2 rounded-lg ${item.color} bg-opacity-10`}>
+                      <Icon className={`w-5 h-5 ${item.color.replace('bg-', 'text-')}`} />
+                    </div>
+                    {item.label}
+                  </CardTitle>
+                  <span className="text-2xl font-bold text-primary">
+                    {formatCurrency(item.amount)}
+                  </span>
+                </div>
+              </CardHeader>
+              <CardContent>
+                <div className="space-y-2">
+                  <div className="flex items-center justify-between text-sm text-muted-foreground">
+                    <span>전체 생활비 대비</span>
+                    <span className="font-semibold">{percentage.toFixed(1)}%</span>
+                  </div>
+                  {/* 프로그레스 바 */}
+                  <div className="w-full bg-muted rounded-full h-2.5 overflow-hidden">
+                    <div
+                      className={`h-full ${item.color} transition-all duration-500 ease-out`}
+                      style={{ width: `${percentage}%` }}
+                    />
+                  </div>
+                </div>
+              </CardContent>
+            </Card>
+          );
+        })}
+
+        {/* 총액 카드 */}
+        <Card className="overflow-hidden hover-lift md:col-span-2 bg-primary text-white">
+          <CardHeader className="pb-3">
+            <div className="flex items-center justify-between">
+              <CardTitle className="text-xl font-bold flex items-center gap-2">
+                <div className="p-2 rounded-lg bg-white/10">
+                  <Wallet className="w-6 h-6" />
+                </div>
+                월 총 생활비
+              </CardTitle>
+              <span className="text-3xl sm:text-4xl font-bold">
+                {formatCurrency(costOfLiving.total)}
+              </span>
+            </div>
+          </CardHeader>
+          <CardContent>
+            <p className="text-white/90 text-sm">
+              숙박비, 식비, 교통비를 포함한 {city.name}에서의 평균 월 생활비입니다.
+              개인의 생활 패턴에 따라 실제 비용은 달라질 수 있습니다.
+            </p>
+          </CardContent>
+        </Card>
+      </div>
+    </section>
+  );
+}

--- a/src/components/sections/RelatedCities.tsx
+++ b/src/components/sections/RelatedCities.tsx
@@ -1,0 +1,84 @@
+import Link from 'next/link';
+import { City } from '@/types';
+import { mockCities } from '@/data/mock/cities';
+import CityCard from '@/components/shared/CityCard';
+import { Button } from '@/components/ui/button';
+import { ArrowRight } from 'lucide-react';
+
+interface RelatedCitiesProps {
+  city: City;
+}
+
+export default function RelatedCities({ city }: RelatedCitiesProps) {
+  // 추천 도시 로직:
+  // 1. 같은 지역의 도시 우선
+  // 2. 생활비 ±20% 범위 내 도시
+  // 3. 좋아요 순으로 정렬
+  // 4. 현재 도시 제외
+  // 5. 최대 4개
+
+  const getRelatedCities = (): City[] => {
+    const costRange = city.costOfLiving.total * 0.2; // ±20%
+    const minCost = city.costOfLiving.total - costRange;
+    const maxCost = city.costOfLiving.total + costRange;
+
+    return mockCities
+      .filter((c) => {
+        // 현재 도시 제외
+        if (c.id === city.id) return false;
+
+        // 같은 지역이거나
+        const sameRegion = c.region === city.region;
+
+        // 비슷한 생활비 범위
+        const similarCost =
+          c.costOfLiving.total >= minCost && c.costOfLiving.total <= maxCost;
+
+        return sameRegion || similarCost;
+      })
+      .sort((a, b) => {
+        // 같은 지역을 우선 순위로
+        const aIsRegion = a.region === city.region ? 1 : 0;
+        const bIsRegion = b.region === city.region ? 1 : 0;
+
+        if (aIsRegion !== bIsRegion) {
+          return bIsRegion - aIsRegion;
+        }
+
+        // 좋아요 수로 정렬
+        return b.likes - a.likes;
+      })
+      .slice(0, 4);
+  };
+
+  const relatedCities = getRelatedCities();
+
+  if (relatedCities.length === 0) {
+    return null;
+  }
+
+  return (
+    <section className="w-full max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-12 bg-muted/30">
+      <div className="mb-8 flex items-center justify-between">
+        <div>
+          <h2 className="text-3xl sm:text-4xl font-bold mb-2">추천 도시</h2>
+          <p className="text-muted-foreground">
+            {city.name}와 비슷한 다른 도시들을 둘러보세요
+          </p>
+        </div>
+        <Link href="/#cities">
+          <Button variant="outline" className="gap-2">
+            더 많은 도시 보기
+            <ArrowRight className="w-4 h-4" />
+          </Button>
+        </Link>
+      </div>
+
+      <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+        {relatedCities.map((relatedCity) => (
+          <CityCard key={relatedCity.id} city={relatedCity} />
+        ))}
+      </div>
+    </section>
+  );
+}

--- a/src/components/shared/CityCard.tsx
+++ b/src/components/shared/CityCard.tsx
@@ -1,11 +1,13 @@
 'use client';
 
-import { useState, memo } from 'react';
+import { useState, useEffect, memo } from 'react';
 import Image from 'next/image';
+import Link from 'next/link';
 import { Card, CardContent, CardHeader } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
 import { City } from '@/types';
 import { formatCurrency } from '@/lib/utils';
+import { getCityPreference, setCityPreference } from '@/lib/localStorage';
 import { ThumbsUp, ThumbsDown } from 'lucide-react';
 
 interface CityCardProps {
@@ -18,124 +20,159 @@ function CityCard({ city }: CityCardProps) {
   const [likeCount, setLikeCount] = useState(city.likes);
   const [dislikeCount, setDislikeCount] = useState(city.dislikes);
 
-  const handleLike = () => {
-    if (liked) {
-      setLiked(false);
-      setLikeCount(prev => prev - 1);
-    } else {
-      setLiked(true);
+  // 로컬 스토리지에서 좋아요/싫어요 상태 로드
+  useEffect(() => {
+    const preference = getCityPreference(city.id);
+    if (preference) {
+      setLiked(preference.liked);
+      setDisliked(preference.disliked);
+
+      // 카운트 조정 (로컬 상태와 저장된 상태 차이만큼)
+      if (preference.liked) {
+        setLikeCount(prev => prev + 1);
+      }
+      if (preference.disliked) {
+        setDislikeCount(prev => prev + 1);
+      }
+    }
+  }, [city.id]);
+
+  const handleLike = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const newLiked = !liked;
+    const newDisliked = newLiked ? false : disliked;
+
+    setLiked(newLiked);
+    if (newLiked) {
       setLikeCount(prev => prev + 1);
       if (disliked) {
         setDisliked(false);
         setDislikeCount(prev => prev - 1);
       }
+    } else {
+      setLikeCount(prev => prev - 1);
     }
+
+    // 로컬 스토리지에 저장
+    setCityPreference(city.id, newLiked, newDisliked);
   };
 
-  const handleDislike = () => {
-    if (disliked) {
-      setDisliked(false);
-      setDislikeCount(prev => prev - 1);
-    } else {
-      setDisliked(true);
+  const handleDislike = (e: React.MouseEvent) => {
+    e.preventDefault();
+    e.stopPropagation();
+
+    const newDisliked = !disliked;
+    const newLiked = newDisliked ? false : liked;
+
+    setDisliked(newDisliked);
+    if (newDisliked) {
       setDislikeCount(prev => prev + 1);
       if (liked) {
         setLiked(false);
         setLikeCount(prev => prev - 1);
       }
+    } else {
+      setDislikeCount(prev => prev - 1);
     }
+
+    // 로컬 스토리지에 저장
+    setCityPreference(city.id, newLiked, newDisliked);
   };
 
   return (
-    <Card className="overflow-hidden hover-lift">
-      <div className="relative h-48">
-        <Image
-          src={city.image}
-          alt={city.name}
-          fill
-          className="object-cover"
-          loading="lazy"
-        />
-        <div className="absolute top-4 right-4 bg-white rounded-full w-12 h-12 flex items-center justify-center text-2xl shadow-md">
-          {city.emoji}
-        </div>
-        {city.featured && (
-          <div className="absolute top-4 left-4">
-            <Badge className="bg-primary text-white">인기</Badge>
+    <Link href={`/cities/${city.id}`} className="block">
+      <Card className="overflow-hidden hover-lift">
+        <div className="relative h-48">
+          <Image
+            src={city.image}
+            alt={city.name}
+            fill
+            className="object-cover"
+            loading="lazy"
+          />
+          <div className="absolute top-4 right-4 bg-white rounded-full w-12 h-12 flex items-center justify-center text-2xl shadow-md">
+            {city.emoji}
           </div>
-        )}
-      </div>
-      <CardHeader className="pb-3">
-        <div className="flex items-start justify-between">
-          <div>
-            <h3 className="text-xl font-bold">{city.name}</h3>
-            <p className="text-sm text-muted-foreground">{city.nameEn}</p>
-          </div>
+          {city.featured && (
+            <div className="absolute top-4 left-4">
+              <Badge className="bg-primary text-white">인기</Badge>
+            </div>
+          )}
         </div>
-      </CardHeader>
-      <CardContent className="space-y-4">
-        <p className="text-sm text-muted-foreground line-clamp-2">
-          {city.description}
-        </p>
+        <CardHeader className="pb-3">
+          <div className="flex items-start justify-between">
+            <div>
+              <h3 className="text-xl font-bold">{city.name}</h3>
+              <p className="text-sm text-muted-foreground">{city.nameEn}</p>
+            </div>
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <p className="text-sm text-muted-foreground line-clamp-2">
+            {city.description}
+          </p>
 
-        <div className="flex items-center justify-between">
-          <div className="flex items-center gap-2">
-            <span className="text-2xl font-bold text-primary">
-              {formatCurrency(city.costOfLiving.total)}
-            </span>
-            <span className="text-sm text-muted-foreground">/월</span>
-          </div>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleLike}
-              className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md p-1"
-              aria-label={liked ? `${city.name} 좋아요 취소` : `${city.name} 좋아요`}
-              aria-pressed={liked}
-            >
-              <ThumbsUp
-                className={`w-5 h-5 ${liked ? 'fill-blue-500 text-blue-500' : 'text-gray-400'}`}
-              />
-              <span className={`text-sm font-medium ${liked ? 'text-blue-500' : 'text-gray-600'}`}>
-                {likeCount}
+          <div className="flex items-center justify-between">
+            <div className="flex items-center gap-2">
+              <span className="text-2xl font-bold text-primary">
+                {formatCurrency(city.costOfLiving.total)}
               </span>
-            </button>
+              <span className="text-sm text-muted-foreground">/월</span>
+            </div>
+            <div className="flex items-center gap-3">
+              <button
+                onClick={handleLike}
+                className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md p-1"
+                aria-label={liked ? `${city.name} 좋아요 취소` : `${city.name} 좋아요`}
+                aria-pressed={liked}
+              >
+                <ThumbsUp
+                  className={`w-5 h-5 ${liked ? 'fill-blue-500 text-blue-500' : 'text-gray-400'}`}
+                />
+                <span className={`text-sm font-medium ${liked ? 'text-blue-500' : 'text-gray-600'}`}>
+                  {likeCount}
+                </span>
+              </button>
 
-            <button
-              onClick={handleDislike}
-              className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded-md p-1"
-              aria-label={disliked ? `${city.name} 싫어요 취소` : `${city.name} 싫어요`}
-              aria-pressed={disliked}
-            >
-              <ThumbsDown
-                className={`w-5 h-5 ${disliked ? 'fill-red-500 text-red-500' : 'text-gray-400'}`}
-              />
-              <span className={`text-sm font-medium ${disliked ? 'text-red-500' : 'text-gray-600'}`}>
-                {dislikeCount}
-              </span>
-            </button>
+              <button
+                onClick={handleDislike}
+                className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded-md p-1"
+                aria-label={disliked ? `${city.name} 싫어요 취소` : `${city.name} 싫어요`}
+                aria-pressed={disliked}
+              >
+                <ThumbsDown
+                  className={`w-5 h-5 ${disliked ? 'fill-red-500 text-red-500' : 'text-gray-400'}`}
+                />
+                <span className={`text-sm font-medium ${disliked ? 'text-red-500' : 'text-gray-600'}`}>
+                  {dislikeCount}
+                </span>
+              </button>
+            </div>
           </div>
-        </div>
 
-        <div className="grid grid-cols-2 gap-2 text-sm">
-          <div>
-            <span className="text-muted-foreground">예산: </span>
-            <span className="font-medium">{city.budget}</span>
+          <div className="grid grid-cols-2 gap-2 text-sm">
+            <div>
+              <span className="text-muted-foreground">예산: </span>
+              <span className="font-medium">{city.budget}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">지역: </span>
+              <span className="font-medium">{city.region_category}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">환경: </span>
+              <span className="font-medium">{city.environment.join(', ')}</span>
+            </div>
+            <div>
+              <span className="text-muted-foreground">계절: </span>
+              <span className="font-medium">{city.best_season.join(', ')}</span>
+            </div>
           </div>
-          <div>
-            <span className="text-muted-foreground">지역: </span>
-            <span className="font-medium">{city.region_category}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">환경: </span>
-            <span className="font-medium">{city.environment.join(', ')}</span>
-          </div>
-          <div>
-            <span className="text-muted-foreground">계절: </span>
-            <span className="font-medium">{city.best_season.join(', ')}</span>
-          </div>
-        </div>
-      </CardContent>
-    </Card>
+        </CardContent>
+      </Card>
+    </Link>
   );
 }
 

--- a/src/lib/localStorage.ts
+++ b/src/lib/localStorage.ts
@@ -1,0 +1,103 @@
+/**
+ * 로컬 스토리지 유틸리티
+ * 도시 좋아요/싫어요 상태를 브라우저에 저장하고 불러옵니다.
+ */
+
+const STORAGE_KEY = 'city-preferences';
+
+export interface CityPreference {
+  liked: boolean;
+  disliked: boolean;
+}
+
+interface CityPreferencesStorage {
+  [cityId: string]: CityPreference;
+}
+
+/**
+ * 특정 도시의 좋아요/싫어요 상태를 가져옵니다.
+ */
+export function getCityPreference(cityId: string): CityPreference | null {
+  // SSR 환경에서 window 객체 체크
+  if (typeof window === 'undefined') {
+    return null;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return null;
+    }
+
+    const preferences: CityPreferencesStorage = JSON.parse(stored);
+    return preferences[cityId] || null;
+  } catch (error) {
+    console.error('Failed to get city preference:', error);
+    return null;
+  }
+}
+
+/**
+ * 특정 도시의 좋아요/싫어요 상태를 저장합니다.
+ */
+export function setCityPreference(
+  cityId: string,
+  liked: boolean,
+  disliked: boolean
+): void {
+  // SSR 환경에서 window 객체 체크
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    const preferences: CityPreferencesStorage = stored ? JSON.parse(stored) : {};
+
+    preferences[cityId] = { liked, disliked };
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  } catch (error) {
+    console.error('Failed to set city preference:', error);
+  }
+}
+
+/**
+ * 특정 도시의 좋아요/싫어요 상태를 삭제합니다.
+ */
+export function clearCityPreference(cityId: string): void {
+  // SSR 환경에서 window 객체 체크
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    const stored = localStorage.getItem(STORAGE_KEY);
+    if (!stored) {
+      return;
+    }
+
+    const preferences: CityPreferencesStorage = JSON.parse(stored);
+    delete preferences[cityId];
+
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(preferences));
+  } catch (error) {
+    console.error('Failed to clear city preference:', error);
+  }
+}
+
+/**
+ * 모든 도시의 좋아요/싫어요 상태를 삭제합니다.
+ */
+export function clearAllCityPreferences(): void {
+  // SSR 환경에서 window 객체 체크
+  if (typeof window === 'undefined') {
+    return;
+  }
+
+  try {
+    localStorage.removeItem(STORAGE_KEY);
+  } catch (error) {
+    console.error('Failed to clear all city preferences:', error);
+  }
+}


### PR DESCRIPTION
## Summary
Issue #1의 Phase 1 (데이터 영속성) 구현을 완료했습니다. 도시 카드와 상세 페이지에서 좋아요/싫어요 상태가 로컬 스토리지에 저장되어 페이지 새로고침 후에도 유지됩니다.

## Changes
### 새로운 파일
- **`src/lib/localStorage.ts`**: 도시 선호도 저장/조회/삭제를 위한 유틸리티 함수
  - `getCityPreference()`: 도시별 좋아요/싫어요 상태 조회
  - `setCityPreference()`: 도시별 선호도 저장
  - `clearCityPreference()`: 특정 도시 선호도 삭제
  - `clearAllCityPreferences()`: 모든 선호도 초기화
  - SSR 환경 대응 (window 객체 체크)

- **`src/app/cities/[id]/page.tsx`**: 도시 상세 페이지
  - Next.js 15 App Router 동적 라우트
  - SEO 메타데이터 자동 생성 (Open Graph, Twitter Card)
  - generateStaticParams로 정적 페이지 생성

- **`src/app/cities/[id]/not-found.tsx`**: 404 페이지

- **`src/components/sections/CityDetailHero.tsx`**: 히어로 섹션
  - 풀스크린 배경 이미지와 그라데이션 오버레이
  - 좋아요/싫어요 UI (로컬스토리지 통합)
  - 월 평균 생활비 표시

- **`src/components/sections/CostBreakdown.tsx`**: 생활비 분석
- **`src/components/sections/CityHighlights.tsx`**: 도시 하이라이트
- **`src/components/sections/CityStats.tsx`**: 도시 통계
- **`src/components/sections/RelatedCities.tsx`**: 관련 도시 추천

### 수정된 파일
- **`src/components/shared/CityCard.tsx`**:
  - Next.js Link 컴포넌트로 전체 카드 래핑 → 클릭 시 상세 페이지 이동
  - 로컬스토리지 통합으로 좋아요/싫어요 상태 영속화
  - useEffect로 컴포넌트 마운트 시 저장된 선호도 로드
  - 이벤트 버블링 방지 (e.preventDefault, e.stopPropagation)

## Features Implemented
✅ **Phase 1 완료: 데이터 영속성**
- [x] 좋아요/싫어요 상태를 로컬 스토리지에 저장
- [x] 사용자별 선호도 트래킹 (브라우저 기반)
- [x] 실시간 카운트 업데이트 기능

✅ **추가 구현 사항**
- [x] 도시 카드 → 상세 페이지 네비게이션
- [x] SEO 메타데이터 및 Open Graph 최적화
- [x] 404 Not Found 페이지

## Test Plan
- [ ] 도시 카드에서 좋아요/싫어요 클릭 후 새로고침 시 상태 유지 확인
- [ ] 도시 카드 클릭 시 상세 페이지로 이동 확인
- [ ] 상세 페이지에서 좋아요/싫어요 상태가 카드와 동기화되는지 확인
- [ ] 존재하지 않는 도시 ID로 접근 시 404 페이지 표시 확인
- [ ] SEO 메타데이터가 올바르게 생성되는지 확인
- [ ] 모바일/데스크톱 반응형 레이아웃 확인
- [ ] 로컬스토리지 데이터 구조 검증 (브라우저 개발자 도구)

## Related Issue
Resolves #1 (Phase 1)

🤖 Generated with [Claude Code](https://claude.com/claude-code)