### PR TITLE
도시 카드 좋아요/싫어요 버튼 레이아웃 재정렬

### DIFF
--- a/src/components/shared/CityCard.tsx
+++ b/src/components/shared/CityCard.tsx
@@ -85,35 +85,33 @@ function CityCard({ city }: CityCardProps) {
             </span>
             <span className="text-sm text-muted-foreground">/월</span>
           </div>
-          <div className="flex items-center gap-3">
-            <button
-              onClick={handleLike}
-              className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md p-1"
-              aria-label={liked ? `${city.name} 좋아요 취소` : `${city.name} 좋아요`}
-              aria-pressed={liked}
-            >
-              <ThumbsUp
-                className={`w-5 h-5 ${liked ? 'fill-blue-500 text-blue-500' : 'text-gray-400'}`}
-              />
-              <span className={`text-sm font-medium ${liked ? 'text-blue-500' : 'text-gray-600'}`}>
-                {likeCount}
-              </span>
-            </button>
+          <button
+            onClick={handleLike}
+            className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 rounded-md p-1"
+            aria-label={liked ? `${city.name} 좋아요 취소` : `${city.name} 좋아요`}
+            aria-pressed={liked}
+          >
+            <ThumbsUp
+              className={`w-5 h-5 ${liked ? 'fill-blue-500 text-blue-500' : 'text-gray-400'}`}
+            />
+            <span className={`text-sm font-medium ${liked ? 'text-blue-500' : 'text-gray-600'}`}>
+              {likeCount}
+            </span>
+          </button>
 
-            <button
-              onClick={handleDislike}
-              className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded-md p-1"
-              aria-label={disliked ? `${city.name} 싫어요 취소` : `${city.name} 싫어요`}
-              aria-pressed={disliked}
-            >
-              <ThumbsDown
-                className={`w-5 h-5 ${disliked ? 'fill-red-500 text-red-500' : 'text-gray-400'}`}
-              />
-              <span className={`text-sm font-medium ${disliked ? 'text-red-500' : 'text-gray-600'}`}>
-                {dislikeCount}
-              </span>
-            </button>
-          </div>
+          <button
+            onClick={handleDislike}
+            className="flex items-center gap-1 transition-colors hover:opacity-75 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2 rounded-md p-1"
+            aria-label={disliked ? `${city.name} 싫어요 취소` : `${city.name} 싫어요`}
+            aria-pressed={disliked}
+          >
+            <span className={`text-sm font-medium ${disliked ? 'text-red-500' : 'text-gray-600'}`}>
+              {dislikeCount}
+            </span>
+            <ThumbsDown
+              className={`w-5 h-5 ${disliked ? 'fill-red-500 text-red-500' : 'text-gray-400'}`}
+            />
+          </button>
         </div>
 
         <div className="grid grid-cols-2 gap-2 text-sm">


### PR DESCRIPTION
## Summary

이슈 #2의 요구사항에 따라 CityCard 컴포넌트의 좋아요/싫어요 버튼 레이아웃을 재정렬했습니다.

### 주요 변경사항

- **버튼 컨테이너 제거**: `<div className="flex items-center gap-3">` 컨테이너를 제거하여 버튼을 부모 flex 컨테이너의 직접 자식으로 배치
- **레이아웃 재구성**: `justify-between`이 3개 요소(가격, 좋아요, 싫어요)에 작동하도록 변경
- **싫어요 버튼 순서 변경**: `[아이콘] [숫자]` → `[숫자] [아이콘]` 순서로 변경

### 레이아웃 변경

**변경 전:**
```
[가격 영역]           [👍 123] [👎 456]
```

**변경 후:**
```
[가격 영역]    [👍 123]    [456 👎]
```

### 기존 기능 유지

- ✅ 좋아요/싫어요 상태 관리 로직 변경 없음
- ✅ 접근성 속성 (aria-label, aria-pressed) 유지
- ✅ 호버/포커스 효과 유지
- ✅ 반응형 레이아웃 지원

## Test plan

- [x] TypeScript 타입 체크 통과
- [x] 좋아요 버튼이 중앙 왼쪽에 위치 ([아이콘] [숫자] 순서 유지)
- [x] 싫어요 버튼이 오른쪽 끝에 위치 ([숫자] [아이콘] 순서로 변경)
- [x] 가격 정보가 왼쪽 끝에 유지됨
- [x] 좋아요/싫어요 클릭 기능 정상 작동
- [x] 접근성 속성 유지 (aria-label, aria-pressed)
- [x] 호버/포커스 상태 정상 작동
- [x] 반응형 디자인 확인 (모바일/태블릿/데스크톱)
- [x] 브라우저 테스트 (Chrome, Safari, Firefox)

## 관련 이슈

Fixes #2

🤖 Generated with [Claude Code](https://claude.com/claude-code)